### PR TITLE
[EXTENDEDSETTINGS] Implement DRS: Dynamic Resolution Switch

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -5,6 +5,8 @@
     <string name="pref_description_adbonswitch">Attiva il debug TCP/IP attraverso interfacce di rete (Wi\u2011Fi, reti USB). Questa opzione verrà disattivata automaticamente al riavvio</string>
     <string name="pref_description_adbonswitchdialog">ATTENZIONE: Quando ADB in rete è attivata, il dispositivo non sarà protetto contro eventuali intrusioni! \n\nUtilizzare questa funzionalità solo quando si è connessi su reti attendibili.\n\nAbilitare questa funzione?</string>
     <string name="pref_title_adbonswitch">ADB attraverso la rete</string>
+    <string name="pref_description_drsdialog">Per cambiare la risoluzione del display bisogna riavviare l\'interfaccia utente.\n\nVuoi continuare?</string>
+    <string name="pref_title_dynres_switch">Risoluzione Display</string>
     <string name="error_connect_to_wifi">Errore: Devi essere collegato su una rete Wi-Fi!</string>
     <string name="pref_description_8mp">Usare la modalità fotocamera 8 MegaPixel per avere un framerate maggiore e foto in modalità notte. Disabilitare per usare la modalità fotocamera 23 MegaPixel.</string>
     <string name="pref_title_8mp">Attiva modalità fotocamera 8MP</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="pref_description_adbonswitch">Enable TCP/IP debugging over network interfaces (Wi\u2011Fi, USB networks). This setting is reset on reboot.</string>
     <string name="pref_description_adbonswitchdialog">WARNING: When ADB over network is enabled, your phone is open for intrusions on all connected networks!\n\nOnly use this feature when you are connected on trusted networks.\n\nDo you really want to enable this function?</string>
     <string name="pref_title_adbonswitch">ADB over network</string>
+    <string name="pref_description_drsdialog">Dynamic Resolution Switch needs to restart the UI.\n\nDo you want to continue?</string>
+    <string name="pref_title_dynres_switch">Dynamic Resolution Switch</string>
     <string name="error_connect_to_wifi">Error: You need to be connected to a WiFi!</string>
     <string name="pref_description_8mp">Use the 8MP camera mode for higher FPS and better nightmode picture quality. Disable to use the 23MP mode.</string>
     <string name="pref_title_8mp">Enable 8MP mode</string>

--- a/res/xml/pref_general.xml
+++ b/res/xml/pref_general.xml
@@ -17,4 +17,10 @@
         android:key="adbon_switch"
         android:summary="@string/pref_description_adbonswitch"
         android:title="@string/pref_title_adbonswitch" />
+
+    <ListPreference
+        android:defaultValue="1"
+        android:key="dynres_list_switch"
+        android:title="@string/pref_title_dynres_switch"
+        android:summary="Current resolution:"/>
 </PreferenceScreen>

--- a/src/sonyxperiadev/extendedsettings/performDRSDialog.java
+++ b/src/sonyxperiadev/extendedsettings/performDRSDialog.java
@@ -1,0 +1,42 @@
+package sonyxperiadev.extendedsettings;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+/**
+ * Created by kholk on 17/07/17.
+ * Dialog to perform Dynamic Resolution switch.
+ * Needed only for incomplete HWC2 implementation.
+ * Base on Googles fire missile dialog
+ */
+
+public class performDRSDialog extends DialogFragment {
+    static String DRS_RESOLUTION_ID = "ResolutionID";
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final int resId = getArguments().getInt(DRS_RESOLUTION_ID);
+
+        // Use the Builder class for convenient dialog construction
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage(R.string.pref_description_drsdialog)
+                .setTitle(R.string.pref_title_dynres_switch)
+                .setCancelable(false)
+                .setPositiveButton(R.string.enable, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        ExtendedSettingsActivity.performDRS(resId);
+                    }
+                })
+                .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        /* Do nothing */
+                    }
+                });
+        // Create the AlertDialog object and return it
+        return builder.create();
+    }
+}
+


### PR DESCRIPTION
The Dynamic Resolution Switch (DRS) functionality allows to
change the display resolution on-the-fly.
Currently, this is done for Android N, which doesn't fully
support the DRS functionality, so this is done through a
final SurfaceFlinger restart, though the correct implementation
is already done and 99% used already.

This commit requires HAL support: even if the current one, as
said, does not support DRS completely, some bits need to get
executed for this feature to work.
The correct implementation needs the full HWC2 display HAL
implementation to work.

Thanks to @oshmoun @myself5 for Java assistance :)



P.S.: This requires the following display HAL patches:
https://android-review.googlesource.com/#/c/437235/
https://android-review.googlesource.com/#/c/437236/