### PR TITLE
[EXTENDEDSETTINGS] Implement DispCal: Display White point Calibration

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,8 @@
     android:sharedUserId="android.uid.system">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.MANAGE_DEVICE_ADMINS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REBOOT" />
 
     <application
@@ -30,11 +32,10 @@
             android:name=".BootBroadcastReceiver"
             android:exported="false"
             android:directBootAware="true">
-            <!-- Listening the BOOT_COMPLETED action for legacy pre-N devices -->
             <intent-filter>
                 <action android:name="android.intent.action.PRE_BOOT_COMPLETED" />
-                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.USER_UNLOCKED" />
             </intent-filter>
         </receiver>
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -26,5 +26,17 @@
                 android:resource="@drawable/ic_extended_settings" />
         </activity>
 
+        <receiver
+            android:name=".BootBroadcastReceiver"
+            android:exported="false"
+            android:directBootAware="true">
+            <!-- Listening the BOOT_COMPLETED action for legacy pre-N devices -->
+            <intent-filter>
+                <action android:name="android.intent.action.PRE_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -7,6 +7,7 @@
     <string name="pref_title_adbonswitch">ADB attraverso la rete</string>
     <string name="pref_description_drsdialog">Per cambiare la risoluzione del display bisogna riavviare l\'interfaccia utente.\n\nVuoi continuare?</string>
     <string name="pref_title_dynres_switch">Risoluzione Display</string>
+    <string name="pref_title_dispcal_switch">Calibrazione Bianco del Display</string>
     <string name="error_connect_to_wifi">Errore: Devi essere collegato su una rete Wi-Fi!</string>
     <string name="pref_description_8mp">Usare la modalità fotocamera 8 MegaPixel per avere un framerate maggiore e foto in modalità notte. Disabilitare per usare la modalità fotocamera 23 MegaPixel.</string>
     <string name="pref_title_8mp">Attiva modalità fotocamera 8MP</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="pref_title_adbonswitch">ADB over network</string>
     <string name="pref_description_drsdialog">Dynamic Resolution Switch needs to restart the UI.\n\nDo you want to continue?</string>
     <string name="pref_title_dynres_switch">Dynamic Resolution Switch</string>
+    <string name="pref_title_dispcal_switch">Display white point calibration</string>
     <string name="error_connect_to_wifi">Error: You need to be connected to a WiFi!</string>
     <string name="pref_description_8mp">Use the 8MP camera mode for higher FPS and better nightmode picture quality. Disable to use the 23MP mode.</string>
     <string name="pref_title_8mp">Enable 8MP mode</string>

--- a/res/xml/pref_general.xml
+++ b/res/xml/pref_general.xml
@@ -23,4 +23,11 @@
         android:key="dynres_list_switch"
         android:title="@string/pref_title_dynres_switch"
         android:summary="Current resolution:"/>
+
+    <ListPreference
+        android:defaultValue="1"
+        android:key="dispcal_list_switch"
+        android:title="@string/pref_title_dispcal_switch"
+        android:summary="Current calibration:"/>
+
 </PreferenceScreen>

--- a/src/sonyxperiadev/extendedsettings/BootBroadcastReceiver.java
+++ b/src/sonyxperiadev/extendedsettings/BootBroadcastReceiver.java
@@ -1,10 +1,15 @@
 package sonyxperiadev.extendedsettings;
 
+import android.app.admin.DevicePolicyManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.UserManager;
 import android.util.Log;
 
+import static android.app.admin.DevicePolicyManager.ENCRYPTION_STATUS_ACTIVATING;
+import static android.app.admin.DevicePolicyManager.ENCRYPTION_STATUS_INACTIVE;
+import static android.app.admin.DevicePolicyManager.ENCRYPTION_STATUS_UNSUPPORTED;
 /**
  * This will be executed after the core system has been initialized,
  * along with providers. This means that any dependency on any system
@@ -20,6 +25,25 @@ public class BootBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         try {
+            DevicePolicyManager polMan = (DevicePolicyManager)
+                    context.getSystemService(Context.DEVICE_POLICY_SERVICE);
+            UserManager userMan = UserManager.get(context);
+            int encryptionStatus = polMan.getStorageEncryptionStatus();
+
+            /* If the device is being encrypted, do NOT touch ANYTHING */
+            if (encryptionStatus == ENCRYPTION_STATUS_ACTIVATING)
+                return;
+
+            /*
+             * If we are at a relatively early Android boot stage, check if the
+             * device is encrypted. If it is, bail out, as we cannot read system
+             * properties right now (and we cannot write to sysfs).
+             */
+            if (!userMan.isUserUnlocked() &&
+                    encryptionStatus != ENCRYPTION_STATUS_INACTIVE &&
+                    encryptionStatus != ENCRYPTION_STATUS_UNSUPPORTED)
+                return;
+
             String sysPref = ExtendedSettingsActivity.getSystemProperty(
                     ExtendedSettingsActivity.PREF_DISPCAL_SETTING);
             if (sysPref == null || sysPref.length() < 1)

--- a/src/sonyxperiadev/extendedsettings/BootBroadcastReceiver.java
+++ b/src/sonyxperiadev/extendedsettings/BootBroadcastReceiver.java
@@ -1,0 +1,36 @@
+package sonyxperiadev.extendedsettings;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+/**
+ * This will be executed after the core system has been initialized,
+ * along with providers. This means that any dependency on any system
+ * app will not be necessarily satisfied and the app may crash if
+ * relying on some.
+ *
+ * BEWARE!! DO NOT ABUSE of this receiver!
+ * -- 07/10/2017 - AngeloGioacchino Del Regno <kholk11@gmail.com>
+ */
+public class BootBroadcastReceiver extends BroadcastReceiver {
+    static final String TAG = "ExtendedSettingsBootReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        try {
+            String sysPref = ExtendedSettingsActivity.getSystemProperty(
+                    ExtendedSettingsActivity.PREF_DISPCAL_SETTING);
+            if (sysPref == null || sysPref.length() < 1)
+                sysPref = "0"; /* 0 = default calibration */
+
+            ExtendedSettingsActivity.performDisplayCalibration(Integer.parseInt(sysPref));
+
+        } catch (Throwable t) {
+            Log.wtf(TAG, "We have crashed. THIS IS AN HORRENDOUS BUG!");
+            Log.wtf(TAG, "Please report this error immediately by opening a new issue on GitHub.\n" +
+                    "--- https://git.io/vduAF --- Thank you!", t);
+        }
+    }
+}

--- a/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
+++ b/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
@@ -53,6 +53,7 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
     protected static final String SYSFS_FB_PCC_PROFILE = "/sys/devices/mdss_dsi_panel/pcc_profile";
 
     protected static final String PREF_8MP_23MP_ENABLED = "persist.camera.8mp.config";
+    protected static final String PREF_DISPCAL_SETTING = "persist.dispcal.setting";
     protected static final String PREF_ADB_NETWORK_COM = "adb.network.port.es";
     private static final String PREF_ADB_NETWORK_READ = "service.adb.tcp.port";
     private static final String PREF_CAMERA_ALT_ACT = "persist.camera.alt.act";
@@ -203,7 +204,9 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
                     confirmPerformDRS(Integer.parseInt((String)value));
                     break;
                 case mDispCalSwitchPref:
-                    performDisplayCalibration(Integer.parseInt((String)value));
+                    boolean performed = performDisplayCalibration(Integer.parseInt((String)value));
+                    if (performed)
+                        setSystemProperty(PREF_DISPCAL_SETTING, (String)value);
                     break;
                 default:
                     break;
@@ -559,16 +562,21 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
         }
     }
 
-    private static void performDisplayCalibration(int calId) {
+    /* WARNING: Be careful! This function is called at PRE_BOOT_COMPLETED stage! */
+    protected static boolean performDisplayCalibration(int calId) {
         try {
             FileWriter sysfsFile = new FileWriter(SYSFS_FB_PCC_PROFILE);
             BufferedWriter writer = new BufferedWriter(sysfsFile);
+            String calIdStr = Integer.toString(calId);
 
-            writer.write(Integer.toString(calId) + '\n');
+            writer.write(calIdStr + '\n');
             writer.close();
 
+            return true;
         } catch (Exception e) {
             e.printStackTrace();
+
+            return false;
         }
     }
 

--- a/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
+++ b/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
@@ -50,6 +50,7 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
 
     protected static final String SYSFS_FB_MODES = "/sys/devices/virtual/graphics/fb0/modes";
     protected static final String SYSFS_FB_MODESET = "/sys/devices/virtual/graphics/fb0/mode";
+    protected static final String SYSFS_FB_PCC_PROFILE = "/sys/devices/mdss_dsi_panel/pcc_profile";
 
     protected static final String PREF_8MP_23MP_ENABLED = "persist.camera.8mp.config";
     protected static final String PREF_ADB_NETWORK_COM = "adb.network.port.es";
@@ -59,6 +60,7 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
     private static final String mCameraAltAct = "alt_act_switch";
     protected static final String mADBOverNetworkSwitchPref = "adbon_switch";
     protected static final String mDynamicResolutionSwitchPref = "dynres_list_switch";
+    protected static final String mDispCalSwitchPref = "dispcal_list_switch";
 
     private static final int BUILT_IN_DISPLAY_ID_MAIN = 0;
 
@@ -66,6 +68,58 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
     protected static AppCompatPreferenceActivity mActivity;
     private SharedPreferences.Editor mPrefEditor;
     private static boolean drsInited = false;
+
+    private enum dispCal {
+        PANEL_CALIB_6000K(0),
+        PANEL_CALIB_F6(1),
+        PANEL_CALIB_D50(2),
+        PANEL_CALIB_D65(3),
+        PANEL_CALIB_END(4);
+
+        private final int val;
+
+        private dispCal(int value) {
+            this.val = value;
+        }
+
+        public int getInt() {
+            return val;
+        }
+
+        public static String getElementName(dispCal elm) {
+            switch (elm) {
+                case PANEL_CALIB_6000K:
+                    return "6000K";
+                case PANEL_CALIB_F6:
+                    return "F6: 4150K";
+                case PANEL_CALIB_D50:
+                    return "D50: 5000K";
+                case PANEL_CALIB_D65:
+                    return "D65: 6500K";
+                default:
+                    return "ERROR: UNKNOWN";
+            }
+        }
+
+        public static String getElementName(int elm) {
+            switch (elm) {
+                case 0:
+                    return "6000K";
+                case 1:
+                    return "F6: 4150K";
+                case 2:
+                    return "D50: 5000K";
+                case 3:
+                    return "D65: 6500K";
+                default:
+                    return "ERROR: UNKNOWN";
+            }
+        }
+
+        public static int lastElement() {
+            return dispCal.PANEL_CALIB_END.getInt();
+        }
+    }
 
     private static final class DisplayParameters {
         private int height;
@@ -148,6 +202,9 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
                 case mDynamicResolutionSwitchPref:
                     confirmPerformDRS(Integer.parseInt((String)value));
                     break;
+                case mDispCalSwitchPref:
+                    performDisplayCalibration(Integer.parseInt((String)value));
+                    break;
                 default:
                     break;
             }
@@ -187,6 +244,8 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
             getPreferenceScreen().removePreference(findPreference(mDynamicResolutionSwitchPref));
         }
 
+        initializeDispCalListPreference();
+        findPreference(mDispCalSwitchPref).setOnPreferenceChangeListener(mPreferenceListener);
 
         String adbN = getSystemProperty(PREF_ADB_NETWORK_READ);
         boolean adbNB = isNumeric(adbN) && (Integer.parseInt(adbN) > 0);
@@ -464,6 +523,53 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
 
         setSystemProperty("ctl.restart", "surfaceflinger");
         /* ToDo: Set nobootanimation back to 0 after SF restart */
+    }
+
+    protected void initializeDispCalListPreference() {
+        String curDispCal;
+        int i;
+
+        try {
+            ListPreference resPref = (ListPreference)findPreference(mDispCalSwitchPref);
+            FileInputStream sysfsFile = new FileInputStream(SYSFS_FB_PCC_PROFILE);
+            BufferedReader fileReader = new BufferedReader(
+                    new InputStreamReader(sysfsFile));
+            curDispCal = fileReader.readLine();
+
+            if (curDispCal == null)
+                curDispCal = new String("Unavailable");
+
+            CharSequence[] entries = new CharSequence[dispCal.lastElement()];
+            CharSequence[] entryValues = new CharSequence[dispCal.lastElement()];
+            for (i = 0; i < dispCal.lastElement(); i++) {
+                entries[i] = dispCal.getElementName(i);
+                entryValues[i] = Integer.toString(i);
+            }
+
+            resPref.setEntries(entries);
+            resPref.setEntryValues(entryValues);
+
+            resPref.setDefaultValue(dispCal.getElementName(Integer.parseInt(curDispCal)));
+            resPref.setValueIndex(Integer.parseInt(curDispCal));
+
+            resPref.setSummary(dispCal.getElementName(Integer.parseInt(curDispCal)));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void performDisplayCalibration(int calId) {
+        try {
+            FileWriter sysfsFile = new FileWriter(SYSFS_FB_PCC_PROFILE);
+            BufferedWriter writer = new BufferedWriter(sysfsFile);
+
+            writer.write(Integer.toString(calId) + '\n');
+            writer.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private static void confirmPerformDRS(int resId) {


### PR DESCRIPTION
    Recently I wrote a PCC Profiling facility in the somc_panel
    kernel driver for SoMC devices displays.
    The PCC profiling facility allows a power user, or a system
    application to apply various predefined calibrations to the
    device's display.
    
    This implements the usage of this new kernel functionality
    for the end user through an easy menu to choose between
    all the available predefined whitepoint calibrations.

    Save the user-chosen white point calibration to a system
    property (persist.dispcal.setting) and implement a receiver
    that listens to the boot intents, such as PRE_BOOT_COMPLETED,
    LOCKED_BOOT_COMPLETED and BOOT_COMPLETED (for pre-N compat)
    and restores the user setting at boot time.
