### PR TITLE
DispCal: update preference when a new calibration is applied

### DIFF
--- a/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
+++ b/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
@@ -204,9 +204,12 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
                     confirmPerformDRS(Integer.parseInt((String)value));
                     break;
                 case mDispCalSwitchPref:
-                    boolean performed = performDisplayCalibration(Integer.parseInt((String)value));
-                    if (performed)
+                    int newDispCal = Integer.parseInt((String)value);
+                    boolean performed = performDisplayCalibration(newDispCal);
+                    if (performed) {
                         setSystemProperty(PREF_DISPCAL_SETTING, (String)value);
+                        updateDispCalPreference(newDispCal);
+                    }
                     break;
                 default:
                     break;
@@ -597,6 +600,14 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
     private static void confirmRebootChange() {
         DialogFragment newFragment = new confirmRebootChangeDialog();
         newFragment.show(mFragmentManager, "8mp");
+    }
+
+    protected static void updateDispCalPreference(int newDispCal) {
+        ListPreference resPref = (ListPreference) ExtendedSettingsActivity.mActivity.findPreference(mDispCalSwitchPref);
+        if(resPref != null) {
+            resPref.setValueIndex(newDispCal);
+            resPref.setSummary(dispCal.getElementName(newDispCal));
+        }
     }
 
     protected static void updateADBSummary(boolean enabled) {


### PR DESCRIPTION
Make sure that the currently visible value in ES always reflect the actual applied calibration.

Change-Id: Iea229115329404c6d797e38e52f0ef785ac454eb