### PR TITLE
ES: preference framework has moved out of v7 folder.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,10 +7,8 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
 LOCAL_PACKAGE_NAME := ExtendedSettings
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVATE_PLATFORM_APIS := true
 LOCAL_PRIVILEGED_MODULE := true
-ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
-    LOCAL_PRIVATE_PLATFORM_APIS := true
-endif
 
 LOCAL_STATIC_JAVA_LIBRARIES := \
     android-support-v4 \

--- a/Android.mk
+++ b/Android.mk
@@ -20,10 +20,17 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
 
 LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/res \
-    frameworks/support/v14/preference/res \
     frameworks/support/v7/appcompat/res \
-    frameworks/support/v7/preference/res \
     frameworks/support/v7/recyclerview/res
+
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+    LOCAL_RESOURCE_DIR += \
+        frameworks/support/preference/res
+else
+    LOCAL_RESOURCE_DIR += \
+        frameworks/support/v14/preference/res \
+        frameworks/support/v7/preference/res
+endif
 
 LOCAL_AAPT_FLAGS := \
     --auto-add-overlay \


### PR DESCRIPTION
@jzoran What comparison operator do you propose in makefiles (https://github.com/sonyxperiadev/transpower/pull/5#discussion_r209561139)? I cannot find anything that doesn't involve `shell`; is there something built into AOSP?

See
https://android.googlesource.com/platform/frameworks/support/+/e94ca6676f8f845741369d4967255f642a4cefbb