### PR TITLE
ES: Grant access to private SDK APIs such as SystemProperties.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -9,7 +9,7 @@ LOCAL_PACKAGE_NAME := ExtendedSettings
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true
 ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
-LOCAL_SDK_VERSION := current
+    LOCAL_PRIVATE_PLATFORM_APIS := true
 endif
 
 LOCAL_STATIC_JAVA_LIBRARIES := \


### PR DESCRIPTION
This sets `LOCAL_PRIVATE_PLATFORM_APIS := true` to be able to use private APIs such as `SystemProperties`.