### PR TITLE
ES: Remove "alternate actuator" remnants.

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -8,8 +8,6 @@
     <string name="pref_description_drsdialog">Dynamic Resolution Switch muss die UI neustarten.\n\nMöchten sie fortfahren?</string>
     <string name="pref_title_dynres_switch">Dynamic Resolution Switch</string>
     <string name="error_connect_to_wifi">Error: W-LAN muss aktiviert sein!</string>
-    <string name="pref_title_alt_act">Alternativen Aktuator nutzen</string>
-    <string name="pref_description_alt_act">Manche Tablets nutzen einen anderen Aktuator. Ändern sie diesen Wert, wenn sie Probleme haben.</string>
     <string name="dialog_reboot_required">Neustart erforderlich</string>
     <string name="dialog_reboot_required_summary">Ein Neustart ist erforderlich, um die Änderungen anzuwenden!</string>
     <string name="reboot_now">Jetzt Neustarten</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -9,8 +9,6 @@
     <string name="pref_title_dynres_switch">Cambio de Resolución Dinámico</string>
     <string name="pref_title_dispcal_switch">Calibración del punto blanco de la pantalla</string>
     <string name="error_connect_to_wifi">Error: ¡Debe estar conectado a una red Wi-Fi!</string>
-    <string name="pref_title_alt_act">Usar el actuador alternativo</string>
-    <string name="pref_description_alt_act">En algunas tabletas tenemos actuadores diferentes, cambie esta configuración si está sufriendo problemas.</string>
     <string name="dialog_reboot_required">Reinicio necesario</string>
     <string name="dialog_reboot_required_summary">¡Es necesario reiniciar para que los cambios surtan efecto!</string>
     <string name="reboot_now">Reiniciar ahora</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -9,8 +9,6 @@
     <string name="pref_title_dynres_switch">Changeur de résolution</string>
     <string name="pref_title_dispcal_switch">Calibration de la couleur d\'écran</string>
     <string name="error_connect_to_wifi">Une connection à un réseau WiFi est nécessaire !</string>
-    <string name="pref_title_alt_act">Use alternate actuator</string>
-    <string name="pref_description_alt_act">On some tablets we have a different actuator, change this settings if you\'re experiencing issues.</string>
     <string name="dialog_reboot_required">Redémarrage requis</string>
     <string name="dialog_reboot_required_summary">Un redémmarage est nécessaire pour prendre en compte les changements !</string>
     <string name="reboot_now">Redémarrer imédiatement</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -9,8 +9,6 @@
     <string name="pref_title_dynres_switch">Risoluzione Display</string>
     <string name="pref_title_dispcal_switch">Calibrazione Bianco del Display</string>
     <string name="error_connect_to_wifi">Errore: Devi essere collegato su una rete Wi-Fi!</string>
-    <string name="pref_title_alt_act">Utilizzare attuatore alternativo</string>
-    <string name="pref_description_alt_act">In alcuni tablets è presente un attuatore alternativo. Attivare questa voce solo se si presentano problemi.</string>
     <string name="dialog_reboot_required">Riavvio richiesto</string>
     <string name="dialog_reboot_required_summary">Un riavvio è necessario perchè le modifiche abbiano effetto!</string>
     <string name="reboot_now">Riavvia ora</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -8,8 +8,6 @@
     <string name="pref_description_drsdialog">解像度の変更には UI の再起動が必要です。\n\n続行しますか？</string>
     <string name="pref_title_dynres_switch">解像度の変更</string>
     <string name="error_connect_to_wifi">エラー: Wi\u2011Fi に接続してください！</string>
-    <string name="pref_title_alt_act">別のアクチュエータを使用する</string>
-    <string name="pref_description_alt_act">一部のタブレットでは通常と異なるアクチュエータを使用しています。問題が発生したらこの設定を変更してください</string>
     <string name="dialog_reboot_required">再起動してください</string>
     <string name="dialog_reboot_required_summary">変更を反映するには再起動してください！</string>
     <string name="reboot_now">今すぐ再起動する</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -7,8 +7,6 @@
   <string name="pref_description_adbonswitchdialog">ADVERTÊNCIA: Quando o ADB através da rede está ativado, o seu telefone está aberto para intrusões em todas as redes ligadas!\n\nApenas use esta funcionalidade quando estiver ligado a redes conhecidas e seguras.\n\nDeseja realmente ativar esta função?</string>
   <string name="pref_title_adbonswitch">ADB em rede</string>
   <string name="error_connect_to_wifi">Erro: Você precisa estar conectado a um WiFi!</string>
-  <string name="pref_title_alt_act">Use um atuador alternativo</string>
-  <string name="pref_description_alt_act">Em alguns dispositivos, temos um atuador diferente, altere essas configurações se tiver problemas.</string>
   <string name="dialog_reboot_required">Reinicialização necessária</string>
   <string name="dialog_reboot_required_summary">Uma reinicialização é necessária para que as alterações tenham efeito!</string>
   <string name="reboot_now">Reiniciar agora</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -10,8 +10,6 @@
   <string name="pref_title_dispcal_switch">Калибровка баланса белого</string>
   <string name="pref_title_adbonswitch">Отладка по сети</string>
   <string name="error_connect_to_wifi">Ошибка: Вы должны быть подключены к Сети!</string>
-  <string name="pref_title_alt_act">Использовать альтернативный датчик</string>
-  <string name="pref_description_alt_act">На некоторых планшетах установлен другой датчик, измените эту настройку, если у вас есть проблемы.</string>
   <string name="dialog_reboot_required">Требуется перезагрузка</string>
   <string name="dialog_reboot_required_summary">Перезагрузка необходима для того, чтобы изменения вступили в силу!</string>
   <string name="reboot_now">Перезагрузить сейчас</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -11,8 +11,6 @@
     <string name="pref_title_dynres_switch">Динамічний перемикач розширення</string>
     <string name="pref_title_dispcal_switch">Калібрування балансу білого</string>
     <string name="error_connect_to_wifi">Помилка: Ви повинні бути підключеними до Wi-Fi мережі!</string>
-    <string name="pref_title_alt_act">Використовувати альтернативний датчик</string>
-    <string name="pref_description_alt_act">На деяких планшетах ми маємо інший датчик, змініть це, якщо у вас виникають з ним проблеми.</string>
     <string name="dialog_reboot_required">Необхідне перезавантаження</string>
     <string name="dialog_reboot_required_summary">Необхідне перезавантаження для того, щоб зміни вступили в силу!</string>
     <string name="reboot_now">Перезавантажити зараз</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -9,8 +9,6 @@
     <string name="pref_title_dynres_switch">显示设置</string>
     <string name="pref_title_dispcal_switch">白平衡设置</string>
     <string name="error_connect_to_wifi">错误: 您需要连接到WiFi！</string>
-    <string name="pref_title_alt_act">使用备用执行器</string>
-    <string name="pref_description_alt_act">在一些平板电脑上我们使用了与手机不同的执行器，如果你遇到了问题，请开启此选项。</string>
     <string name="dialog_reboot_required">需要重启</string>
     <string name="dialog_reboot_required_summary">设备需要重启以使更改生效！</string>
     <string name="reboot_now">立即重启</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -9,8 +9,6 @@
     <string name="pref_title_dynres_switch">Dynamic Resolution Switch</string>
     <string name="pref_title_dispcal_switch">Display white point calibration</string>
     <string name="error_connect_to_wifi">Error: You need to be connected to a WiFi!</string>
-    <string name="pref_title_alt_act">Use alternate actuator</string>
-    <string name="pref_description_alt_act">On some tablets we have a different actuator, change this settings if you\'re experiencing issues.</string>
     <string name="dialog_reboot_required">Reboot required</string>
     <string name="dialog_reboot_required_summary">A reboot is required for the changes to take effect!</string>
     <string name="reboot_now">Reboot now</string>

--- a/res/xml/pref_general.xml
+++ b/res/xml/pref_general.xml
@@ -1,12 +1,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <SwitchPreference
-        android:defaultValue="true"
-        android:key="alt_act_switch"
-        android:summary="@string/pref_description_alt_act"
-        android:title="@string/pref_title_alt_act" />
-
-    <SwitchPreference
         android:defaultValue="false"
         android:key="adbon_switch"
         android:summary="@string/pref_description_adbonswitch"


### PR DESCRIPTION
The code for this feature was removed in #48, but strings and
`SwitchPreference` were left in place.