### PR TITLE
Revert "ES: Using private APIs does not require SDK guard."

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,9 +7,12 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
 LOCAL_PACKAGE_NAME := ExtendedSettings
 LOCAL_CERTIFICATE := platform
-LOCAL_PRIVATE_PLATFORM_APIS := true
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROPRIETARY_MODULE := true
+
+ifeq (1,$(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= 28 ))" )))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 LOCAL_USE_AAPT2 := true
 


### PR DESCRIPTION
When using PRODUCT_SHIPPING_API_LEVEL := 28 this would result in
 `Specifies both LOCAL_SDK_VERSION (system_current) and LOCAL_PRIVATE_PLATFORM_APIS (true) but should specify only one 
`

Lets put a guard in place to check current shipping api level and if its bigger or equal to 28 (P) then do not set LOCAL_PRIVATE_PLATFORM_APIS.