### PR TITLE
Add a guard to check for SHIPPING_API_LEVEL

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,9 +7,12 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
 LOCAL_PACKAGE_NAME := ExtendedSettings
 LOCAL_CERTIFICATE := platform
-LOCAL_PRIVATE_PLATFORM_APIS := true
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROPRIETARY_MODULE := true
+
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 LOCAL_USE_AAPT2 := true
 


### PR DESCRIPTION
Lets add a guard to check for shipping api level and if its equal to SDK version. 

This fixes error in building if shipping api level is equal to SDK version.

`Specifies both LOCAL_SDK_VERSION (system_current) and LOCAL_PRIVATE_PLATFORM_APIS (true) but should specify only one`