### PR TITLE
[master] Implement method changes on R

### DIFF
--- a/src/sonyxperiadev/extendedsettings/ExtendedSettingsFragment.java
+++ b/src/sonyxperiadev/extendedsettings/ExtendedSettingsFragment.java
@@ -281,15 +281,15 @@ public class ExtendedSettingsFragment extends PreferenceFragment {
      */
     protected static String getAvailableResolutions(int dispId) {
         IBinder dispHandle = SurfaceControl.getPhysicalDisplayToken(dispId);
-        SurfaceControl.PhysicalDisplayInfo[] displayCfgs =
+        SurfaceControl.DisplayConfig[] displayCfgs =
                 SurfaceControl.getDisplayConfigs(dispHandle);
         int currentCfgNo = SurfaceControl.getActiveConfig(dispHandle);
         String ret;
 
-        SurfaceControl.PhysicalDisplayInfo currentCfg = displayCfgs[currentCfgNo];
+        SurfaceControl.DisplayConfig currentCfg = displayCfgs[currentCfgNo];
         Log.d(TAG, "Current resolution: " + currentCfg.width + "x" +
                     currentCfg.height + " @ " + currentCfg.refreshRate +
-                    "hz, " + currentCfg.density + "DPI");
+                    "hz, ");
         ret = currentCfg.width + "x" + currentCfg.height + "@" +
                 currentCfg.refreshRate + "hz";
         return ret;
@@ -447,7 +447,7 @@ public class ExtendedSettingsFragment extends PreferenceFragment {
         }
 
         int curMode = SurfaceControl.getActiveConfig(displayHandle);
-        SurfaceControl.PhysicalDisplayInfo[] displayCfgs =
+        SurfaceControl.DisplayConfig[] displayCfgs =
                 SurfaceControl.getDisplayConfigs(displayHandle);
 
         width = displayCfgs[resId].width;

--- a/src/sonyxperiadev/extendedsettings/ExtendedSettingsFragment.java
+++ b/src/sonyxperiadev/extendedsettings/ExtendedSettingsFragment.java
@@ -72,6 +72,8 @@ public class ExtendedSettingsFragment extends PreferenceFragment {
 
     private static final long BUILT_IN_DISPLAY_ID_MAIN = SurfaceControl.getPhysicalDisplayIds()[0];
 
+    private static native boolean nativeSetActiveConfig(IBinder displayToken, int id);
+
     private static FragmentManager mFragmentManager;
     static PreferenceFragment mFragment;
     private SharedPreferences.Editor mPrefEditor;
@@ -416,6 +418,16 @@ public class ExtendedSettingsFragment extends PreferenceFragment {
         }
     }
 
+    /**
+     * @hide
+     */
+    public static boolean setActiveConfig(IBinder displayToken, int id) {
+        if (displayToken == null) {
+            throw new IllegalArgumentException("displayToken must not be null");
+        }
+        return nativeSetActiveConfig(displayToken, id);
+    }
+
     protected static void performDRS(int resId) {
         IBinder displayHandle = SurfaceControl.getPhysicalDisplayToken(BUILT_IN_DISPLAY_ID_MAIN);
         int width, height;
@@ -444,14 +456,14 @@ public class ExtendedSettingsFragment extends PreferenceFragment {
         /* This is an hack for incomplete HWC2 implementation */
         if ((resId == curMode) && (resId < 1)) {
             SurfaceControl.openTransaction();
-            SurfaceControl.setActiveConfig(displayHandle, curMode + 1);
+            setActiveConfig(displayHandle, curMode + 1);
             SurfaceControl.closeTransaction();
         }
         /* END */
 
         SurfaceControl.openTransaction();
 
-        SurfaceControl.setActiveConfig(displayHandle, resId);
+        setActiveConfig(displayHandle, resId);
         SurfaceControl.setDisplaySize(displayHandle, width, height);
 
         SurfaceControl.closeTransaction();


### PR DESCRIPTION
1. For `setActiveConfig()`. google removed it and recommend to make it private. So we import it. [Google-git](https://android.googlesource.com/platform/frameworks/base.git/+/e8d9d6526644cc8601352ab0291f0b4566f9175e)

I am not sure this is the right way to fix it because google provided` setActiveConfigWithConstraints` to replace` setActiveConfig`, however it is a cpp one?
[android-source](https://source.android.com/devices/graphics/multiple-refresh-rate#implementation)

2. `PhysicalDisplayInfo` is replaced by `DisplayConfig` on R. [Google-git](https://android.googlesource.com/platform/frameworks/base.git/+/69b281d5f3ad61490bd8795795cefaa1f4674401)