### PR TITLE
[S/T] AndroidManifest.xml: Set android:exported to true

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:theme="@style/Theme.Main">
         <activity
             android:name=".ExtendedSettingsActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.android.settings.action.EXTRA_SETTINGS" />
             </intent-filter>


### PR DESCRIPTION
All applications targeting Android 12+ that use intent filter in activity
must specify a value for android:exported.

On A12 we did not get this error but an warning. But the app wont show up
in settings.

Ref: https://developer.android.com/guide/topics/manifest/activity-element#exported

Please change target to T branch when created and cherry pick to S branch as well.